### PR TITLE
Ignore duplicated hops and correctly handle hops which never return a response

### DIFF
--- a/lib/mtr.js
+++ b/lib/mtr.js
@@ -142,7 +142,7 @@ Mtr.prototype._spawn = function(cmd, args) {
 
 Mtr.prototype._parseResult = function(output) {
   var lines, line, i, split, type, hopNumber, data, value, result, tempResult,
-      maxHopNumber = 0, item;
+      maxHopNumber = 0, item, seenTarget = false, targetHopNumber = null;
 
   lines = output.split('\n');
 
@@ -163,6 +163,12 @@ Mtr.prototype._parseResult = function(output) {
     hopNumber = parseInt(split[1], 10);
     data = split[2];
 
+    if (seenTarget && hopNumber > targetHopNumber) {
+      // Indicate that we have seen the target and we can ignore all the hops
+      // with the same ip beyond this one.
+      continue;
+    }
+
     if (hopNumber > maxHopNumber) {
       maxHopNumber = hopNumber;
     }
@@ -178,6 +184,11 @@ Mtr.prototype._parseResult = function(output) {
 
     if (type === 'h') {
       tempResult[hopNumber].ip = data;
+
+      if (data === this._target) {
+        seenTarget = true;
+        targetHopNumber = hopNumber;
+      }
     }
     else if (type === 'p') {
       value = (parseInt(data, 10) / 1000);

--- a/lib/mtr.js
+++ b/lib/mtr.js
@@ -217,6 +217,9 @@ Mtr.prototype._parseResult = function(output) {
       };
     }
 
+    // Be consistent with traceroute and use 1-based hop number
+    item.number++;
+
     result.push(item);
   }
 

--- a/lib/mtr.js
+++ b/lib/mtr.js
@@ -208,7 +208,13 @@ Mtr.prototype._parseResult = function(output) {
     item = tempResult[i];
 
     if (!item) {
-      continue;
+      // Hops for which we never got a response.
+      item = {
+        'ip': null,
+        'hostname': null,
+        'number': i,
+        'rtts': []
+      };
     }
 
     result.push(item);

--- a/tests/test-traceroute.js
+++ b/tests/test-traceroute.js
@@ -73,7 +73,7 @@ exports['test_error_invalid_target'] = function(test, assert) {
 };
 
 exports['test_traceroute_route_1'] = function(test, assert) {
-  var hopCount, splitHops, hopNumber, mtr;
+  var hopCount, splitHops, hopNumber, mtr, branchCount = 0;
 
   hopCount = 0;
   splitHops = {};
@@ -94,6 +94,7 @@ exports['test_traceroute_route_1'] = function(test, assert) {
     splitHops[hopNumber] = splitHops[hopNumber] + 1;
 
     if (hopNumber === 1) {
+      branchCount++;
       assert.equal(hop.number, 1);
       assert.equal(hop.ip, '127.0.0.1');
       assert.deepEqual(hop.rtts, [0.087, 0.075, 0.077, 0.08, 0.076, 0.075,
@@ -102,13 +103,14 @@ exports['test_traceroute_route_1'] = function(test, assert) {
   });
 
   mtr.on('end', function() {
+    assert.equal(branchCount, 1);
     assert.equal(hopNumber, 1);
     test.finish();
   });
 };
 
 exports['test_traceroute_route_2'] = function(test, assert) {
-  var hopCount, splitHops, hopNumber, mtr;
+  var hopCount, splitHops, hopNumber, mtr, branchCount = 0;
 
   hopCount = 0;
   splitHops = {};
@@ -129,31 +131,36 @@ exports['test_traceroute_route_2'] = function(test, assert) {
     splitHops[hopNumber] = splitHops[hopNumber] + 1;
 
     if (hopNumber === 1) {
+      branchCount++;
       assert.equal(hop.number, 1);
       assert.equal(hop.ip, '50.56.129.162');
       assert.deepEqual(hop.rtts, [1.011, 0.739, 0.824, 0.737, 0.743, 0.648,
                                   0.799, 0.725, 0.724, 0.787]);
     }
     else if (hopNumber === 14) {
+      branchCount++;
       assert.equal(hop.number, 14);
       assert.equal(hop.ip, '8.8.8.8');
     }
   });
 
   mtr.on('end', function() {
+    assert.equal(branchCount, 2);
     assert.equal(hopNumber, 14);
     test.finish();
   });
 };
 
 exports['test_traceroute_route_with_hostnames'] = function(test, assert) {
-  var mtr;
+  var mtr, hopNumber;
 
   mtr = new Mtr('8.8.8.8', {resolveDns: true});
   Mtr.prototype._spawn = exports.getEmitter('./tests/fixtures/normal_output_to_8.8.8.8_with_hostnames.txt');
   mtr.traceroute();
 
   mtr.on('hop', function(hop) {
+    hopNumber = hop.number;
+
     if (hop.number === 15) {
       assert.equal(hop.number, 15);
       assert.equal(hop.hostname, 'google-public-dns-a.google.com');
@@ -162,6 +169,7 @@ exports['test_traceroute_route_with_hostnames'] = function(test, assert) {
   });
 
   mtr.on('end', function() {
+    assert.equal(hopNumber, 15);
     test.finish();
   });
 };

--- a/tests/test-traceroute.js
+++ b/tests/test-traceroute.js
@@ -99,15 +99,10 @@ exports['test_traceroute_route_1'] = function(test, assert) {
       assert.deepEqual(hop.rtts, [0.087, 0.075, 0.077, 0.08, 0.076, 0.075,
                                   0.07, 0.086, 0.076, 0.084]);
     }
-    else if (hopNumber === 1) {
-      assert.equal(hop.number, 1);
-      assert.equal(hop.ip, '127.0.0.1');
-      assert.deepEqual(hop.rtts, [0.028]);
-    }
   });
 
   mtr.on('end', function() {
-    assert.equal(hopNumber, 1);
+    assert.equal(hopNumber, 0);
     test.finish();
   });
 };
@@ -139,15 +134,14 @@ exports['test_traceroute_route_2'] = function(test, assert) {
       assert.deepEqual(hop.rtts, [1.011, 0.739, 0.824, 0.737, 0.743, 0.648,
                                   0.799, 0.725, 0.724, 0.787]);
     }
-    else if (hopNumber === 14) {
-      assert.equal(hop.number, 14);
+    else if (hopNumber === 13) {
+      assert.equal(hop.number, 13);
       assert.equal(hop.ip, '8.8.8.8');
-      assert.deepEqual(hop.rtts, [52.775]);
     }
   });
 
   mtr.on('end', function() {
-    assert.equal(hopNumber, 14);
+    assert.equal(hopNumber, 13);
     test.finish();
   });
 };

--- a/tests/test-traceroute.js
+++ b/tests/test-traceroute.js
@@ -93,8 +93,8 @@ exports['test_traceroute_route_1'] = function(test, assert) {
 
     splitHops[hopNumber] = splitHops[hopNumber] + 1;
 
-    if (hopNumber === 0) {
-      assert.equal(hop.number, 0);
+    if (hopNumber === 1) {
+      assert.equal(hop.number, 1);
       assert.equal(hop.ip, '127.0.0.1');
       assert.deepEqual(hop.rtts, [0.087, 0.075, 0.077, 0.08, 0.076, 0.075,
                                   0.07, 0.086, 0.076, 0.084]);
@@ -102,7 +102,7 @@ exports['test_traceroute_route_1'] = function(test, assert) {
   });
 
   mtr.on('end', function() {
-    assert.equal(hopNumber, 0);
+    assert.equal(hopNumber, 1);
     test.finish();
   });
 };
@@ -128,20 +128,20 @@ exports['test_traceroute_route_2'] = function(test, assert) {
 
     splitHops[hopNumber] = splitHops[hopNumber] + 1;
 
-    if (hopNumber === 0) {
-      assert.equal(hop.number, 0);
+    if (hopNumber === 1) {
+      assert.equal(hop.number, 1);
       assert.equal(hop.ip, '50.56.129.162');
       assert.deepEqual(hop.rtts, [1.011, 0.739, 0.824, 0.737, 0.743, 0.648,
                                   0.799, 0.725, 0.724, 0.787]);
     }
-    else if (hopNumber === 13) {
-      assert.equal(hop.number, 13);
+    else if (hopNumber === 14) {
+      assert.equal(hop.number, 14);
       assert.equal(hop.ip, '8.8.8.8');
     }
   });
 
   mtr.on('end', function() {
-    assert.equal(hopNumber, 13);
+    assert.equal(hopNumber, 14);
     test.finish();
   });
 };
@@ -154,8 +154,8 @@ exports['test_traceroute_route_with_hostnames'] = function(test, assert) {
   mtr.traceroute();
 
   mtr.on('hop', function(hop) {
-    if (hop.number === 14) {
-      assert.equal(hop.number, 14);
+    if (hop.number === 15) {
+      assert.equal(hop.number, 15);
       assert.equal(hop.hostname, 'google-public-dns-a.google.com');
       assert.equal(hop.ip, '8.8.8.8');
     }


### PR DESCRIPTION
This branch implements 2 fixed based on findings in #2:
1. After we have first seen the hop for a final destination, ignore hops with the same target which come afterward (have bigger hop number).
2. Correctly handle hops which never return a response
